### PR TITLE
Upgrade to Netty 4.1.50.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
 		<!-- test dependencies -->
 		<logback.version>1.2.3</logback.version>
-		<netty.version>4.1.46.Final</netty.version>
+		<netty.version>4.1.50.Final</netty.version>
 		<hamcrest.library.version>2.2</hamcrest.library.version>
 		<hamcrest.jpa-matchers>1.8</hamcrest.jpa-matchers>
 		<lambdaj.version>2.3.3</lambdaj.version>


### PR DESCRIPTION
Hi

Package Owner: Abhishek kumar nishant

PR change Details:
$Patch Details : Following file has been modified:

.pom.xml:
Modified pom.xml to update netty version from '4.1.48.Final' to '4.1.50.Final'.

$Testing Detail:

After doing the changes,verified working by executing 'mvn test' command and all test cases are running fine on x86 and aarch64 both platforms

$PR Description :Here is my commit message :

Upgrade Netty to its latest version 4.1.50.Final for both security fixes and AArch64 performance improvements

Body

The update netty ver 4.1.50 includes both security fixes and AArch64 performance improvements
Refer release notes for detail: https://netty.io/news/2020/05/13/4-1-50-Final.html


Signed-off-by: odidev odidev@puresoftware.com

$ Peer Reviewer: Shweta Singh
$ Reviewer: Shobhit Parashri